### PR TITLE
Rename base speed globals

### DIFF
--- a/src/obstacles.lua
+++ b/src/obstacles.lua
@@ -7,7 +7,7 @@ function init_obstacles()
     -- Frames between spawns
     max_obstacles = 4
     obstacle_y = 110
-    base_speed = 1.5
+    obstacle_base_speed = 1.5
     speed_variation = 0.5
 end
 
@@ -16,7 +16,7 @@ function spawn_obstacle()
         local new_obstacle = {
             x = 128, -- Start off-screen to the right
             y = obstacle_y - rnd(40),
-            speed = base_speed + rnd(speed_variation * 2) - speed_variation,
+            speed = obstacle_base_speed + rnd(speed_variation * 2) - speed_variation,
             sprite = 5
         }
         add(obstacles, new_obstacle)

--- a/src/platforms.lua
+++ b/src/platforms.lua
@@ -56,7 +56,7 @@ end
 -- ======================================================
 
 function init_platforms()
-  base_speed = 0.5
+  platform_base_speed = 0.5
   platforms = {}
   plat_widths = { 2, 3, 4 } -- Possible widths
 
@@ -146,7 +146,7 @@ function spawn_platform()
     return
   end -- No free slots, can't spawn right now
 
-  local speed = base_speed + rnd(0.5)
+  local speed = platform_base_speed + rnd(0.5)
   local x, y
 
   -- Calculate position from the slot index, guaranteeing no overlap


### PR DESCRIPTION
## Summary
- rename `base_speed` in obstacles and platforms modules
- update spawn logic to use `obstacle_base_speed` and `platform_base_speed`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6858831c2e8c8326b910ac62fa6aeac1