### PR TITLE
Implement platform cleanup and state encapsulation

### DIFF
--- a/src/collision.lua
+++ b/src/collision.lua
@@ -101,7 +101,7 @@ function check_platform_landing(player_x, player_y, goal_x, goal_y, vel_y)
   local earliest_collision = nil
   local collision_platform = nil
 
-  for plat in all(platforms) do
+  for plat in all(PlatformManager.platforms) do
     local t, nx, ny, tx, ty, intersect = swept_aabb_collision(player_x, player_y, player_w, player_h, plat.x, plat.y, plat.width * 8, 8, goal_x, goal_y)
 
     -- Only consider top surface collisions (normal pointing up)

--- a/src/game_manager.lua
+++ b/src/game_manager.lua
@@ -85,6 +85,7 @@ function check_direction_change()
     -- Only change if we need to
     if target_direction ~= current_direction then
         current_direction = target_direction
+        cleanup_platforms(current_direction)
     end
 end
 

--- a/src/player.lua
+++ b/src/player.lua
@@ -131,14 +131,16 @@ function Player:move()
     end
 
     -- Apply platform speed if on one
-    if self.on_ground and plat_speed then 
-
+    if self.on_ground and plat_speed then
         if platform.direction == DIRECTIONS.RIGHT_TO_LEFT then
             self.x -= plat_speed
         elseif platform.direction == DIRECTIONS.LEFT_TO_RIGHT then
             self.x += plat_speed
+        elseif platform.direction == DIRECTIONS.UP_TO_DOWN then
+            self.y += plat_speed
+        elseif platform.direction == DIRECTIONS.DOWN_TO_UP then
+            self.y -= plat_speed
         end
-
 
         if self.x < 0 then
             self.x = 0


### PR DESCRIPTION
## Summary
- encapsulate platform state into `PlatformManager`
- support width-aware platform spawn offsets and clamped vertical spawns
- remove outdated platforms when directions change
- apply vertical platform motion to the player
- update modules for new table-based manager

## Testing
- `luajit -b src/platforms.lua /dev/null` *(fails: command not found)*
- `pico8 -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858818def3883269e1bd974289aa0ea